### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,7 @@ fn seek_the_path(
         if *solved && !no_skip {
             println!(
                 "{}",
-                info_style().paint(format!("\t✅ {} (Skipped)", definition))
+                info_style().paint(format!("\t✅ {} (Passed)", definition))
             );
             continue;
         }


### PR DESCRIPTION
For new students, "skipped" message and a green checkmark can cause a lot confusion. Changed Skipped to Passed to clarify the exercise has been passed.