### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can see it in action in the [rust-telemetry-workshop](https://github.com/mai
 ## Installation
 
 ```bash
-cargo install workshop-runner
+cargo install --locked workshop-runner
 ```
 
 Check that it has been installed correctly:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
         A Rust workshop runner
         </strong>
     </div>
-
     <div align="center">
         <!-- Crates version -->
         <a href="https://crates.io/crates/cargo-px">


### PR DESCRIPTION
When installing `wr` in preparation for [Rust Nation 2025](https://www.rustnationuk.com/) I noticed a minor rendering and an inconsistency issue with the `README.md`:
* [crates.io](https://crates.io/) badges were not rendering correctly at the top of the page.
* [GH pages site](https://mainmatter.github.io/rust-workshop-runner/) states to use `--locked` when running `cargo install` which is inconsistent with the README